### PR TITLE
[WIP] Add a score system for rare items

### DIFF
--- a/.github/workflows/build-branch.yaml
+++ b/.github/workflows/build-branch.yaml
@@ -5,14 +5,16 @@ on: workflow_dispatch
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v2
+      with:
+        msbuild-architecture: x86
     - uses: actions/checkout@master
     - name: MSBuild
-      run: msbuild /t:BH:Rebuild /p:Configuration=Release /p:CustomDefinitions=`"SHA=\`"($env:GITHUB_SHA.substring(0,7))\`"`" BH.sln
+      run: msbuild /t:BH:Rebuild /p:Configuration=Release /p:SHA=${GITHUB_SHA::7} BH.sln
     - uses: actions/upload-artifact@v2
       with:
         name: BH.dll

--- a/.github/workflows/build-branch.yaml
+++ b/.github/workflows/build-branch.yaml
@@ -5,17 +5,17 @@ on: workflow_dispatch
 jobs:
   build:
 
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v2
       with:
         msbuild-architecture: x86
-#    - uses: actions/checkout@master
-#    - name: MSBuild
-#      run: msbuild /t:BH:Rebuild /p:Configuration=Release /p:SHA=${GITHUB_SHA::7} BH.sln
-#    - uses: actions/upload-artifact@v4
-#      with:
-#        name: BH.dll
-#        path: Release/BH.dll
+    - uses: actions/checkout@master
+    - name: MSBuild
+      run: msbuild /t:BH:Rebuild /p:Configuration=Release /p:SHA=${GITHUB_SHA::7} BH.sln
+    - uses: actions/upload-artifact@v4
+      with:
+        name: BH.dll
+        path: Release/BH.dll

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -7,17 +7,17 @@ on:
 jobs:
   build:
 
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v2
       with:
         msbuild-architecture: x86
-#    - uses: actions/checkout@master
-#    - name: MSBuild
-#      run: msbuild /t:BH:Rebuild /p:Configuration=Release /p:SHA=${GITHUB_SHA::7} BH.sln
-#    - uses: actions/upload-artifact@v4
-#      with:
-#        name: BH.dll
-#        path: Release/BH.dll
+    - uses: actions/checkout@master
+    - name: MSBuild
+      run: msbuild /t:BH:Rebuild /p:Configuration=Release /p:SHA=${GITHUB_SHA::7} BH.sln
+    - uses: actions/upload-artifact@v4
+      with:
+        name: BH.dll
+        path: Release/BH.dll

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -7,14 +7,16 @@ on:
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v2
+      with:
+        msbuild-architecture: x86
     - uses: actions/checkout@master
     - name: MSBuild
-      run: msbuild /t:BH:Rebuild /p:Configuration=Release /p:CustomDefinitions=`"SHA=\`"($env:GITHUB_SHA.substring(0,7))\`"`" BH.sln
+      run: msbuild /t:BH:Rebuild /p:Configuration=Release /p:SHA=${GITHUB_SHA::7} BH.sln
     - uses: actions/upload-artifact@v2
       with:
         name: BH.dll

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -108,6 +108,7 @@ void Item::OnLoad() {
 void ResetCaches() {
 	item_desc_cache.ResetCache();
 	item_name_cache.ResetCache();
+	item_score_cache.ResetCache();
 	map_action_cache.ResetCache();
 	do_not_block_cache.ResetCache();
 	ignore_cache.ResetCache();
@@ -1017,7 +1018,20 @@ void __stdcall Item::OnPropertyBuild(wchar_t* wOut, int nStat, UnitAny* pItem, i
 					statMax += all_stat->dwMax;
 				}
 
-				if (stat->dwMin != stat->dwMax) {
+				if (nStat == STAT_STRENGTHPERLEVEL) {
+					int	aLen = wcslen(wOut);
+					int leftSpace = 128 - aLen > 0 ? 128 - aLen : 0;
+					statMin = D2COMMON_GetBaseStatSigned(D2CLIENT_GetPlayerUnit(), STAT_STRENGTHPERLEVEL, 0);
+					statMax = D2COMMON_GetBaseStatSigned(D2CLIENT_GetPlayerUnit(), STAT_STRENGTHPERLEVEL, 0);
+					if (leftSpace)
+						swprintf_s(wOut + aLen, leftSpace,
+							L" %s[%d - %d]%s",
+							GetColorCode(statRangeColor).c_str(),
+							statMin,
+							statMax,
+							GetColorCode(TextColor::Blue).c_str());
+				}
+				else if (stat->dwMin != stat->dwMax) {
 					int	aLen = wcslen(wOut);
 					int leftSpace = 128 - aLen > 0 ? 128 - aLen : 0;
 
@@ -1154,6 +1168,9 @@ ItemsTxtStat* GetItemsTxtStatByMod(ItemsTxtStat* pStats, int nStats, int nStat, 
 			return &pStats[i];
 		}
 		else if (pProp->wStat[0] == 0xFFFF && pProp->nFunc[0] == 5 && (nStat == STAT_MINIMUMDAMAGE || nStat == STAT_SECONDARYMINIMUMDAMAGE)) {
+			return &pStats[i];
+		}
+		else if ( pProp->nFunc[0] == 17 && (nStat == STAT_STRENGTHPERLEVEL)) {
 			return &pStats[i];
 		}
 		for (int j = 0; j < 7; ++j)


### PR DESCRIPTION
This hasn't really been tested at all (lewd is planning on testing it) but if anyone wanted to try it out, I figured I'd make a pull request. It allows you to filter items based on a "score" you create for the item. Score start at `1` and can be manipulated with `+-*/` i.e.

```
ItemDisplay[RING FCR>1 SCORE*3]: %CONTINUE%
ItemDisplay[RING STR>1 SCORE+5]: %CONTINUE%
ItemDisplay[RING FRES>1 SCORE+10]: %CONTINUE%
ItemDisplay[RING CRES>1 SCORE+5]: %CONTINUE%
ItemDisplay[RING LRES>1 SCORE-5]: %CONTINUE%
ItemDisplay[SCORE>10]: %SCORE%%NAME%
```

The above example was just thrown together and isn't really good, but for instance if you found a ring w/ FCR, STR, and FRES then the score would be 18 and it would be kept by the last line in the filter. Figure this could be yet another way to filter rare items to decide which are good.