### PR TITLE
fix minimap position when hd

### DIFF
--- a/BH/Modules/Maphack/Maphack.cpp
+++ b/BH/Modules/Maphack/Maphack.cpp
@@ -31,8 +31,8 @@ Patch* skipNpcMessages2 = new Patch(Call, D2CLIENT, { 0x48BD6, 0x7B4C6 }, (int)N
 Patch* skipNpcMessages3 = new Patch(Call, D2CLIENT, { 0x4819F, 0x7A9CF }, (int)NPCQuestMessageEndPatch2_ASM, 5);
 Patch* skipNpcMessages4 = new Patch(Call, D2CLIENT, { 0x7E9B7, 0x77737 }, (int)NPCMessageLoopPatch_ASM, 6);
 
-Patch* minimapOffsetX = new Patch(Byte, D2CLIENT, { 0x60d39, 0x0 }, 0x3D, 1); //0x28 is default value
-Patch* minimapOffsetY = new Patch(Byte, D2CLIENT, { 0x60d3d, 0x0 }, 0xF, 1); //0xF is default value
+Patch* minimapOffsetXPatch = new Patch(Byte, D2CLIENT, { 0x60d39, 0x718b9 }, 0x28, 1); //0x28 is default value
+Patch* minimapOffsetYPatch = new Patch(Byte, D2CLIENT, { 0x60d3d, 0x718bd }, 0xF, 1); //0xF is default value
 
 
 static BOOL fSkipMessageReq = 0;
@@ -53,6 +53,11 @@ Maphack::Maphack() : Module("Maphack") {
 	monsterColors["Champion"] = 0x91;
 	monsterColors["Boss"] = 0x84;
 
+	minimapOffsetX["640x480"] = 0x28;
+	minimapOffsetX["800x600"] = 0x2D;
+	minimapOffsetX["856x480"] = 0x32;
+	minimapOffsetX["1068x600"] = 0x3D;
+
 	monsterResistanceThreshold = 99;
 	lkLinesColor = 105;
 
@@ -71,6 +76,8 @@ void Maphack::LoadConfig() {
 
 void Maphack::ReadConfig() {
 	BH::config->ReadInt("Reveal Mode", revealType);
+	BH::config->ReadAssoc("Minimap Offset X", minimapOffsetX);
+	BH::config->ReadAssoc("Minimap Offset Y", minimapOffsetY);
 	BH::config->ReadInt("Show Monster Resistance", monsterResistanceThreshold);
 	BH::config->ReadInt("LK Chest Lines", lkLinesColor);
 
@@ -181,6 +188,8 @@ void Maphack::ReadConfig() {
 
 	BH::config->ReadToggle("Show Normal Monsters", "None", true, Toggles["Show Normal Monsters"]);
 	BH::config->ReadInt("Minimap Max Ghost", automapDraw.maxGhost);
+
+	UpdateMinimapSettings();
 }
 
 void Maphack::ResetRevealed() {
@@ -189,6 +198,20 @@ void Maphack::ResetRevealed() {
 		revealedAct[act] = false;
 	for (int level = 0; level < 255; level++)
 		revealedLevel[level] = false;
+}
+
+void Maphack::UpdateMinimapSettings() {
+	char resolution[128];
+	prevScreenSizeX = *p_D2CLIENT_ScreenSizeX;
+	prevScreenSizeY = *p_D2CLIENT_ScreenSizeY;
+	sprintf_s(resolution, "%dx%d", *p_D2CLIENT_ScreenSizeX, *p_D2CLIENT_ScreenSizeY);
+	minimapOffsetXPatch->SetFunction(minimapOffsetX.count(resolution) > 0 ? minimapOffsetX[resolution] : 0x28);
+	minimapOffsetYPatch->SetFunction(minimapOffsetY.count(resolution) > 0 ? minimapOffsetY[resolution] : 0xF);
+	
+	// Refreshes the patch so it will reinstall with new values on a config reload.
+	minimapOffsetXPatch->Remove();
+	minimapOffsetYPatch->Remove();
+
 }
 
 void Maphack::ResetPatches() {
@@ -244,12 +267,12 @@ void Maphack::ResetPatches() {
 	}
 
 	if (Toggles["Minimap HD Fix"].state) {
-		minimapOffsetX->Install();
-		minimapOffsetY->Install();
+		minimapOffsetXPatch->Install();
+		minimapOffsetYPatch->Install();
 	}
 	else {
-		minimapOffsetX->Remove();
-		minimapOffsetY->Remove();
+		minimapOffsetXPatch->Remove();
+		minimapOffsetYPatch->Remove();
 	}
 }
 
@@ -370,8 +393,8 @@ void Maphack::OnUnload() {
 	skipNpcMessages3->Remove();
 	skipNpcMessages4->Remove();
 	diabloDeadMessage->Remove();
-	minimapOffsetX->Remove();
-	minimapOffsetY->Remove();
+	minimapOffsetXPatch->Remove();
+	minimapOffsetYPatch->Remove();
 }
 
 void Maphack::OnLoop() {
@@ -421,6 +444,12 @@ Act* lastAct = NULL;
 
 void Maphack::OnDraw() {
 	UnitAny* player = D2CLIENT_GetPlayerUnit();
+
+	// Screen resolution change
+	if (prevScreenSizeX != *p_D2CLIENT_ScreenSizeX
+		|| prevScreenSizeY != *p_D2CLIENT_ScreenSizeY) {
+		UpdateMinimapSettings();
+	}
 
 	if (!player || !player->pAct || player->pPath->pRoom1->pRoom2->pLevel->dwLevelNo == 0)
 		return;
@@ -739,6 +768,7 @@ void Maphack::OnAutomapDraw() {
 void Maphack::OnGameJoin() {
 	ResetRevealed();
 	automapLevels.clear();
+	UpdateMinimapSettings();
 	*p_D2CLIENT_AutomapOn = Toggles["Show Automap On Join"].state;
 }
 

--- a/BH/Modules/Maphack/Maphack.cpp
+++ b/BH/Modules/Maphack/Maphack.cpp
@@ -31,6 +31,9 @@ Patch* skipNpcMessages2 = new Patch(Call, D2CLIENT, { 0x48BD6, 0x7B4C6 }, (int)N
 Patch* skipNpcMessages3 = new Patch(Call, D2CLIENT, { 0x4819F, 0x7A9CF }, (int)NPCQuestMessageEndPatch2_ASM, 5);
 Patch* skipNpcMessages4 = new Patch(Call, D2CLIENT, { 0x7E9B7, 0x77737 }, (int)NPCMessageLoopPatch_ASM, 6);
 
+Patch* minimapOffsetX = new Patch(Byte, D2CLIENT, { 0x60d39, 0x0 }, 0x3D, 1); //0x28 is default value
+Patch* minimapOffsetY = new Patch(Byte, D2CLIENT, { 0x60d3d, 0x0 }, 0xF, 1); //0xF is default value
+
 
 static BOOL fSkipMessageReq = 0;
 static DWORD mSkipMessageTimer = 0;
@@ -174,6 +177,7 @@ void Maphack::ReadConfig() {
 	BH::config->ReadToggle("Apply FPS Patch", "None", true, Toggles["Apply FPS Patch"]);
 	BH::config->ReadToggle("Show Automap On Join", "None", false, Toggles["Show Automap On Join"]);
 	BH::config->ReadToggle("Skip NPC Quest Messages", "None", true, Toggles["Skip NPC Quest Messages"]);
+	BH::config->ReadToggle("Minimap HD Fix", "None", true, Toggles["Minimap HD Fix"]);
 
 	BH::config->ReadToggle("Show Normal Monsters", "None", true, Toggles["Show Normal Monsters"]);
 	BH::config->ReadInt("Minimap Max Ghost", automapDraw.maxGhost);
@@ -238,6 +242,15 @@ void Maphack::ResetPatches() {
 		skipNpcMessages3->Remove();
 		skipNpcMessages4->Remove();
 	}
+
+	if (Toggles["Minimap HD Fix"].state) {
+		minimapOffsetX->Install();
+		minimapOffsetY->Install();
+	}
+	else {
+		minimapOffsetX->Remove();
+		minimapOffsetY->Remove();
+	}
 }
 
 void Maphack::OnLoad() {
@@ -299,6 +312,9 @@ void Maphack::OnLoad() {
 	new Checkhook(settingsTab, 4, (Y += 15), &Toggles["Skip NPC Quest Messages"].state, "Skip NPC Quest Messages");
 	new Keyhook(settingsTab, keyhook_x, (Y + 2), &Toggles["Skip NPC Quest Messages"].toggle, "");
 
+	new Checkhook(settingsTab, 4, (Y += 15), &Toggles["Minimap HD Fix"].state, "Minimap HD Fix");
+	new Keyhook(settingsTab, keyhook_x, (Y + 2), &Toggles["Minimap HD Fix"].toggle, "");
+
 	new Texthook(settingsTab, col2_x + 5, 3, "Missile Colors");
 
 	new Colorhook(settingsTab, col2_x, 17, &missileColors["Player"], "Player");
@@ -354,6 +370,8 @@ void Maphack::OnUnload() {
 	skipNpcMessages3->Remove();
 	skipNpcMessages4->Remove();
 	diabloDeadMessage->Remove();
+	minimapOffsetX->Remove();
+	minimapOffsetY->Remove();
 }
 
 void Maphack::OnLoop() {

--- a/BH/Modules/Maphack/Maphack.h
+++ b/BH/Modules/Maphack/Maphack.h
@@ -22,8 +22,11 @@ struct BaseSkill {
 
 class Maphack : public Module {
 	private:
+		int prevScreenSizeX = 640, prevScreenSizeY = 480;
 		int monsterResistanceThreshold;
 		int lkLinesColor;
+		std::map<string, unsigned int> minimapOffsetX;
+		std::map<string, unsigned int> minimapOffsetY;
 		unsigned int revealType;
 		unsigned int maxGhostSelection;
 		unsigned int reloadConfig;
@@ -73,6 +76,8 @@ class Maphack : public Module {
 
 	static Level* GetLevel(Act* pAct, int level);
 	static AutomapLayer* InitLayer(int level);
+
+	void UpdateMinimapSettings();
 };
 
 void Weather_Interception();

--- a/BH/Patch.cpp
+++ b/BH/Patch.cpp
@@ -79,6 +79,10 @@ bool Patch::Install() {
 			code[1] = function;
 		}
 	}
+	
+	if (type == Byte) {
+		code[0] = (BYTE)function;
+	}
 
 	//Write the patch in
 	VirtualProtect((VOID*)address, length, PAGE_EXECUTE_READWRITE, &protect);

--- a/BH/Patch.cpp
+++ b/BH/Patch.cpp
@@ -117,3 +117,7 @@ bool Patch::Remove() {
 
 	return true;
 }
+
+void Patch::SetFunction(int function) {
+	this->function = function;
+}

--- a/BH/Patch.h
+++ b/BH/Patch.h
@@ -6,7 +6,7 @@
 class Patch;
 
 enum Dll { D2CLIENT=0,D2COMMON,D2GFX,D2LANG,D2WIN,D2NET,D2GAME,D2LAUNCH,FOG,BNCLIENT, STORM, D2CMP, D2MULTI, D2MCPCLIENT};
-enum PatchType { Jump=0xE9, Call=0xE8, NOP=0x90, Push=0x6A };
+enum PatchType { Jump=0xE9, Call=0xE8, NOP=0x90, Push=0x6A, Byte=0x0 };
 
 struct Offsets {
 	int _113c;

--- a/BH/Patch.h
+++ b/BH/Patch.h
@@ -29,6 +29,8 @@ class Patch {
 
 		bool IsInstalled() { return injected; };
 
+		void SetFunction(int function);
+
 		static int GetDllOffset(Dll dll, int offset);
 		static bool WriteBytes(int address, int len, BYTE* bytes);
 };


### PR DESCRIPTION
Adds a toggle to shit the minimap over by default some pixels. Without the toggle

![image](https://github.com/user-attachments/assets/b19dd419-a9e2-4cba-9299-7453ccdbc25b)

with the toggle

![image](https://github.com/user-attachments/assets/92d5ee25-afa4-4e9c-80f3-2a89100f0002)
